### PR TITLE
Add routine badge and filter support for task/commitment lists

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.qf26ovlu0l8"
+    "revision": "0.d8uklmkgulo"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/CommitmentsList.tsx
+++ b/src/components/CommitmentsList.tsx
@@ -18,6 +18,7 @@ const CATEGORIES = [
   'Finance',
   'Home',
   'Organization',
+  'Routine',
   'Buffer',
 ];
 
@@ -41,6 +42,8 @@ const getCategoryColor = (category: string) => {
       return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300';
     case 'Buffer':
       return 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300';
+    case 'Routine':
+      return 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-300';
     default:
       return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-300';
   }
@@ -220,6 +223,11 @@ const CommitmentsList: React.FC<CommitmentsListProps> = ({
                     >
                       {commitment.category}
                     </span>
+                    {commitment.category === 'Routine' && (
+                      <span className="px-2 py-1 text-xs font-medium rounded-full bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200 flex-shrink-0">
+                        Routine
+                      </span>
+                    )}
                   </div>
                   <div className="space-y-2">
                     {commitment.isAllDay ? (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -963,6 +963,11 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
                             Important
                           </span>
                         )}
+                        {task.category === 'Routine' && (
+                            <span className="text-xs bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full dark:bg-indigo-900 dark:text-indigo-200 flex-shrink-0">
+                            Routine
+                          </span>
+                        )}
                         </div>
                         
                         <div className="space-y-2">


### PR DESCRIPTION
## Purpose

The user identified that the task list and commitment list were missing routine badges for visual identification, and the commitment list lacked the ability to filter by routine categories. This change addresses both UI consistency and filtering functionality gaps.

## Code changes

- **CommitmentsList.tsx**: Added 'Routine' to the CATEGORIES array to enable filtering, implemented routine category color styling (teal theme), and added a routine badge display for commitments with routine category
- **TaskList.tsx**: Added routine badge display for tasks with routine category using indigo theme styling
- **Service worker**: Updated revision hash for deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/daf02d0b160640fc97ac0b487af3d3e1/pulse-zone)

👀 [Preview Link](https://daf02d0b160640fc97ac0b487af3d3e1-pulse-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>daf02d0b160640fc97ac0b487af3d3e1</projectId>-->
<!--<branchName>pulse-zone</branchName>-->