### PR TITLE
Remove redundant routine badges from task and commitment lists

### DIFF
--- a/src/components/CommitmentsList.tsx
+++ b/src/components/CommitmentsList.tsx
@@ -223,11 +223,6 @@ const CommitmentsList: React.FC<CommitmentsListProps> = ({
                     >
                       {commitment.category}
                     </span>
-                    {commitment.category === 'Routine' && (
-                      <span className="px-2 py-1 text-xs font-medium rounded-full bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200 flex-shrink-0">
-                        Routine
-                      </span>
-                    )}
                   </div>
                   <div className="space-y-2">
                     {commitment.isAllDay ? (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -963,11 +963,6 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
                             Important
                           </span>
                         )}
-                        {task.category === 'Routine' && (
-                            <span className="text-xs bg-indigo-100 text-indigo-800 px-2 py-1 rounded-full dark:bg-indigo-900 dark:text-indigo-200 flex-shrink-0">
-                            Routine
-                          </span>
-                        )}
                         </div>
                         
                         <div className="space-y-2">


### PR DESCRIPTION
## Purpose
The user identified redundant badges for routine items that were being displayed unnecessarily. This change removes the duplicate routine badges to clean up the UI and eliminate visual redundancy.

## Code changes
- Removed redundant "Routine" badge from `CommitmentsList.tsx` that was displaying alongside the category badge
- Removed redundant "Routine" badge from `TaskList.tsx` that was showing in addition to the existing category display
- Both components already show the category information, making these additional routine-specific badges unnecessary

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/daf02d0b160640fc97ac0b487af3d3e1/spark-verse)

👀 [Preview Link](https://daf02d0b160640fc97ac0b487af3d3e1-spark-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>daf02d0b160640fc97ac0b487af3d3e1</projectId>-->
<!--<branchName>spark-verse</branchName>-->